### PR TITLE
Correctly set datasource for Version and Uptime

### DIFF
--- a/src/dashboards/data-analysis.json
+++ b/src/dashboards/data-analysis.json
@@ -82,6 +82,10 @@
   "liveNow": false,
   "panels": [
     {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${DS_CLICKHOUSE}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -181,6 +185,10 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${DS_CLICKHOUSE}"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {


### PR DESCRIPTION
The Stat visualizations for Version and Server uptime do not correctly set the datasource on import